### PR TITLE
chore: normalize dataset ignore paths in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,10 @@ htmlcov/
 .env
 .env.*
 !.env.example
-data\flights_full.csv
-data\hotels_full.csv
-data\sessions_full.csv
-data\users_full.csv
+data/flights_full.csv
+data/hotels_full.csv
+data/sessions_full.csv
+data/users_full.csv
 
 
 # =========================


### PR DESCRIPTION
### Motivation
- Normalize dataset ignore entries to use forward slashes for cross-platform consistency and correct path matching in `.gitignore`.

### Description
- Replace Windows-style `data\*.csv` entries with POSIX-style `data/*.csv` in `.gitignore` so dataset files are ignored consistently across environments.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974eff708a4832b90b46def01b903a5)