### PR TITLE
Handle run directory conflicts for CLI runs

### DIFF
--- a/src/traveltide/cli.py
+++ b/src/traveltide/cli.py
@@ -18,6 +18,7 @@ from traveltide.eda import run_eda
 from traveltide.eda.dq_report import cmd_dq_report
 from traveltide.features.pipeline import run_features
 from traveltide.perks.mapping import write_customer_perks
+from traveltide.pipeline import run_end_to_end
 from traveltide.reports.executive_summary import cmd_executive_summary
 from traveltide.reports.final_report import cmd_final_report
 from traveltide.segmentation.run import run_segmentation_job
@@ -56,6 +57,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--mode",
         default="golden-path",
         help="Execution mode placeholder (reserved for future pipeline modes).",
+    )
+    run.add_argument(
+        "--seed",
+        default=None,
+        type=int,
+        help="Optional random seed for reproducibility.",
+    )
+    run.add_argument(
+        "--run-id",
+        default=None,
+        help="Optional run identifier used to name the artifacts folder.",
+    )
+    run.add_argument(
+        "--outdir",
+        default=str(Path("artifacts") / "runs"),
+        help="Base output directory for pipeline runs (default: artifacts/runs).",
     )
 
     # Notes: TT-012 reproducible EDA report generator (artifact emitter).
@@ -182,10 +199,15 @@ def cmd_info(show_env: bool) -> int:
 
 
 # Notes: Placeholder command to preserve a stable automation entrypoint.
-def cmd_run(mode: str) -> int:
-    # Notes: Provides a stable placeholder command so automation/docs can reference it before implementation.
-    print("Golden path placeholder: pipeline not implemented yet.")
-    print(f"Requested mode: {mode}")
+def cmd_run(mode: str, seed: int | None, run_id: str | None, outdir: str) -> int:
+    # Notes: Creates a run directory and captures metadata to keep automation stable.
+    run_dir = run_end_to_end(mode=mode, seed=seed, run_id=run_id, outdir=outdir)
+    if run_id and run_dir.name != run_id:
+        print(
+            "Requested run-id already exists. "
+            f"Created run directory: {run_dir.name}"
+        )
+    print(f"Run directory: {run_dir}")
     return 0
 
 
@@ -210,7 +232,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     # Notes: "run" command routing.
     if args.command == "run":
-        return cmd_run(mode=str(args.mode))
+        return cmd_run(
+            mode=str(args.mode),
+            seed=args.seed,
+            run_id=args.run_id,
+            outdir=str(args.outdir),
+        )
 
     # Notes: "eda" command routing.
     if args.command == "eda":

--- a/src/traveltide/cli.py
+++ b/src/traveltide/cli.py
@@ -203,10 +203,7 @@ def cmd_run(mode: str, seed: int | None, run_id: str | None, outdir: str) -> int
     # Notes: Creates a run directory and captures metadata to keep automation stable.
     run_dir = run_end_to_end(mode=mode, seed=seed, run_id=run_id, outdir=outdir)
     if run_id and run_dir.name != run_id:
-        print(
-            "Requested run-id already exists. "
-            f"Created run directory: {run_dir.name}"
-        )
+        print(f"Requested run-id already exists. Created run directory: {run_dir.name}")
     print(f"Run directory: {run_dir}")
     return 0
 

--- a/src/traveltide/pipeline.py
+++ b/src/traveltide/pipeline.py
@@ -1,0 +1,51 @@
+"""End-to-end pipeline orchestration for TravelTide runs."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _timestamp_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
+
+
+def _build_run_dir(base_dir: Path, run_id: str | None) -> Path:
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    if run_id:
+        candidate = base_dir / run_id
+    else:
+        candidate = base_dir / _timestamp_slug()
+
+    if not candidate.exists():
+        candidate.mkdir(parents=True, exist_ok=False)
+        return candidate
+
+    suffix = _timestamp_slug()
+    fallback = base_dir / f"{candidate.name}-{suffix}"
+    fallback.mkdir(parents=True, exist_ok=False)
+    return fallback
+
+
+def run_end_to_end(
+    *,
+    mode: str,
+    seed: int | None,
+    run_id: str | None,
+    outdir: str,
+) -> Path:
+    """Create a run directory and capture metadata for a pipeline run."""
+
+    run_dir = _build_run_dir(Path(outdir), run_id)
+    metadata: dict[str, Any] = {
+        "mode": mode,
+        "seed": seed,
+        "run_id": run_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    metadata_path = run_dir / "run_metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    return run_dir


### PR DESCRIPTION
### Motivation
- Prevent `FileExistsError` when re-running the pipeline by making run directory creation tolerant of existing `run-id` folders.
- Persist minimal run metadata (mode, seed, run_id, created_at) for reproducibility and automation visibility.
- Expose `--seed`, `--run-id`, and `--outdir` on the `traveltide run` CLI to allow deterministic runs and configurable artifact locations.

### Description
- Add `src/traveltide/pipeline.py` with `_timestamp_slug`, `_build_run_dir`, and `run_end_to_end` to create a run directory, fallback to a timestamp-suffixed directory if a requested `run-id` exists, and write `run_metadata.json`.
- Update `src/traveltide/cli.py` to import `run_end_to_end`, add `--seed`, `--run-id`, and `--outdir` arguments to the `run` subcommand, and change `cmd_run` to call `run_end_to_end` and print the resolved run directory (including a message when the requested `run-id` already existed).
- Wire the new arguments through `main` so `traveltide run` invokes the new run orchestration with the provided options.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69751dc308ac832b993a615929b7aa30)